### PR TITLE
Export required classes and change grpc-sink init method

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -74,10 +74,6 @@
             <artifactId>grpc-stub</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.siddhi</groupId>
-            <artifactId>siddhi-annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
@@ -167,16 +163,16 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>
                             io.siddhi.extension.io.grpc.*,
-                            org.wso2.grpc.*
+                            io.grpc.*,
+                            org.wso2.grpc.*,
+                            com.google.protobuf.*
                         </Export-Package>
                         <Private-Package>
-                            io.grpc.*;-split-package:=merge-first,
                             com.google.*;-split-package:=merge-first,
                             io.opencensus.*,
                             io.perfmark.*,
                         </Private-Package>
                         <Import-Package>
-                            io.grpc.*;version="${grpc.version.range}",
                             com.google.guava*;version="${guava.version.range}",
                             *;resolution:=optional
                         </Import-Package>
@@ -187,10 +183,6 @@
                         </Include-Resource>
                     </instructions>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -164,16 +164,16 @@
                         <Export-Package>
                             io.siddhi.extension.io.grpc.*,
                             io.grpc.*,
+                            com.google.*,
                             org.wso2.grpc.*,
                             com.google.protobuf.*
                         </Export-Package>
                         <Private-Package>
-                            com.google.*;-split-package:=merge-first,
                             io.opencensus.*,
                             io.perfmark.*,
                         </Private-Package>
                         <Import-Package>
-                            com.google.guava*;version="${guava.version.range}",
+                            com.google.guava.*;version="${guava.version.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>

--- a/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcCallSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcCallSink.java
@@ -209,7 +209,7 @@ import static io.siddhi.extension.io.grpc.util.GrpcUtils.getRpcMethodList;
                 @Parameter(
                         name = "enable.ssl",
                         description = "to enable ssl. If set to true and truststore.file is not given then it will " +
-                                "be set to default carbon jks by default" ,
+                                "be set to default carbon jks by default",
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "FALSE"),
@@ -308,9 +308,9 @@ public class GrpcCallSink extends AbstractGrpcSink {
                 }
             }
             if (rpcMethod == null) { //only if user has provided a wrong method name
-                throw new SiddhiAppValidationException(siddhiAppName + ": " + streamID + ": Invalid method name " +
-                        "provided in the url, provided method name: " + serviceConfigs.getMethodName() +
-                        "expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
+                throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
+                        "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
+                        "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
                         streamID));
             }
         } catch (ClassNotFoundException e) {
@@ -391,10 +391,10 @@ public class GrpcCallSink extends AbstractGrpcSink {
             try {
                 genericFutureResponse = (ListenableFuture) rpcMethod.invoke(currentStub, payload);
             } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new SiddhiAppValidationException(siddhiAppName + ": " + streamID + ": Invalid method name " +
-                        "provided in the url, provided method name: " + serviceConfigs.getMethodName() +
-                        "expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
-                        streamID), e);
+                throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
+                        "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
+                        "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
+                        streamID));
             }
             Futures.addCallback(genericFutureResponse, new FutureCallback<Object>() {
                 Map<String, String> siddhiRequestEventData = getRequestEventDataMap(dynamicOptions);
@@ -486,8 +486,8 @@ public class GrpcCallSink extends AbstractGrpcSink {
                     .getFullyQualifiedServiceName() + "'", e);
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
-                    "provided in the url, provided method name: " + serviceConfigs.getMethodName() +
-                    "expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName, streamID));
+                    "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
+                    "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName, streamID));
         }
     }
 }

--- a/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcCallSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcCallSink.java
@@ -394,7 +394,7 @@ public class GrpcCallSink extends AbstractGrpcSink {
                 throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
                         "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
                         "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
-                        streamID));
+                        streamID), e);
             }
             Futures.addCallback(genericFutureResponse, new FutureCallback<Object>() {
                 Map<String, String> siddhiRequestEventData = getRequestEventDataMap(dynamicOptions);
@@ -487,7 +487,8 @@ public class GrpcCallSink extends AbstractGrpcSink {
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
                     "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
-                    "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName, streamID));
+                    "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName, streamID)
+                    , e);
         }
     }
 }

--- a/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcCallSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcCallSink.java
@@ -57,7 +57,12 @@ import static io.siddhi.extension.io.grpc.util.GrpcUtils.getRpcMethodList;
         description = "This extension publishes event data encoded into GRPC Classes as defined in the user input " +
                 "jar. This extension has a default gRPC service classes jar added. The default service is called " +
                 "\"EventService\". Please find the protobuf definition [here](https://github.com/siddhi-io/" +
-                "siddhi-io-grpc/tree/master/component/src/main/resources/EventService.proto). This grpc-call sink is " +
+                "siddhi-io-grpc/tree/master/component/src/main/resources/EventService.proto). If we want to use our " +
+                "custom gRPC services, we have to  pack auto-generated gRPC service classes and  protobuf classes " +
+                "into a jar file and add it into the project classpath (or to the `jars` folder in the `siddhi-" +
+                "tooling` folder if we use it with `siddhi-tooling`). Please find the custom protobuf definition that" +
+                " uses in examples [here](https://github.com/siddhi-io/siddhi-io-grpc/tree/master/component/src/main/" +
+                "resources/sample.proto). This grpc-call sink is " +
                 "used for scenarios where we send a request out and expect a response back. In default mode this " +
                 "will use EventService process method. grpc-call-response source is used to receive the responses. " +
                 "A unique sink.id is used to correlate between the sink and its corresponding source.",

--- a/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcSink.java
@@ -26,6 +26,7 @@ import io.siddhi.annotation.Extension;
 import io.siddhi.annotation.Parameter;
 import io.siddhi.annotation.util.DataType;
 import io.siddhi.core.exception.ConnectionUnavailableException;
+import io.siddhi.core.exception.SiddhiAppRuntimeException;
 import io.siddhi.core.util.snapshot.state.State;
 import io.siddhi.core.util.transport.DynamicOptions;
 import io.siddhi.core.util.transport.OptionHolder;
@@ -381,7 +382,7 @@ public class GrpcSink extends AbstractGrpcSink {
                         requestObserver = (StreamObserver) rpcMethod.invoke(asyncStub, responseObserver);
                     }
                 } catch (IllegalAccessException | InvocationTargetException e) { //throws from 'invoke'
-                    throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
+                    throw new SiddhiAppRuntimeException(siddhiAppName + ":" + streamID + ": Invalid method name " +
                             "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
                             "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
                             streamID), e);
@@ -429,11 +430,11 @@ public class GrpcSink extends AbstractGrpcSink {
             Method newStub = serviceClass.getDeclaredMethod(GrpcConstants.NEW_STUB_NAME, Channel.class);
             return (AbstractStub) newStub.invoke(serviceClass, this.channel);
         } catch (ClassNotFoundException e) {
-            throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid service name " +
+            throw new SiddhiAppRuntimeException(siddhiAppName + ":" + streamID + ": Invalid service name " +
                     "provided in the url, provided service name: '" + serviceConfigs
                     .getFullyQualifiedServiceName() + "'", e);
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-            throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
+            throw new SiddhiAppRuntimeException(siddhiAppName + ":" + streamID + ": Invalid method name " +
                     "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
                     "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName, streamID)
             , e);

--- a/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcSink.java
@@ -225,7 +225,6 @@ import static io.siddhi.extension.io.grpc.util.GrpcUtils.getRpcMethodList;
                                 " be running at 134.23.43.35 listening to port 8080 since there is no mapper " +
                                 "provided, attributes of stream definition should be as same as the attributes of " +
                                 "protobuf message definition."
-
                 ),
                 @Example(syntax = "" +
                         "@sink(type='grpc',\n" +
@@ -273,37 +272,6 @@ public class GrpcSink extends AbstractGrpcSink {
     private AbstractStub asyncStub;
     private StreamObserver requestObserver;
     private Method rpcMethod;
-
-    /**
-     * to get the rpc method from the service
-     */
-    private static Method getRpcMethod(ServiceConfigs serviceConfigs, String siddhiAppName, String streamID) {
-
-        Method rpcMethod = null;
-        String stubReference = serviceConfigs.getFullyQualifiedServiceName() + GrpcConstants.
-                GRPC_PROTOCOL_NAME_UPPERCAMELCASE + GrpcConstants.DOLLAR_SIGN + serviceConfigs.getServiceName()
-                + GrpcConstants.STUB;
-        try {
-            Method[] methodsInStub = Class.forName(stubReference).getMethods();
-            for (Method method : methodsInStub) {
-                if (method.getName().equalsIgnoreCase(serviceConfigs.getMethodName())) {
-                    rpcMethod = method;
-                    break;
-                }
-            }
-            if (rpcMethod == null) { //only if user has provided a wrong method name
-                throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
-                        "provided in the url, provided method name: " + serviceConfigs.getMethodName() +
-                        "expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
-                        streamID));
-            }
-        } catch (ClassNotFoundException e) {
-            throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid service name " +
-                    "provided in the url, provided service name: '" + serviceConfigs
-                    .getFullyQualifiedServiceName() + "'", e);
-        }
-        return rpcMethod;
-    }
 
     @Override
     public void initSink(OptionHolder optionHolder) {
@@ -356,7 +324,6 @@ public class GrpcSink extends AbstractGrpcSink {
             throws ConnectionUnavailableException {
         if (serviceConfigs.isDefaultService()) {
             Event.Builder eventBuilder = Event.newBuilder().setPayload(payload.toString());
-
             if (headersOption != null || serviceConfigs.getSequenceName() != null) {
                 if (headersOption != null && headersOption.isStatic()) {
                     eventBuilder.putAllHeaders(headersMap);
@@ -471,5 +438,36 @@ public class GrpcSink extends AbstractGrpcSink {
                     "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName, streamID)
             , e);
         }
+    }
+
+    /**
+     * to get the rpc method from the service
+     */
+    private static Method getRpcMethod(ServiceConfigs serviceConfigs, String siddhiAppName, String streamID) {
+
+        Method rpcMethod = null;
+        String stubReference = serviceConfigs.getFullyQualifiedServiceName() + GrpcConstants.
+                GRPC_PROTOCOL_NAME_UPPERCAMELCASE + GrpcConstants.DOLLAR_SIGN + serviceConfigs.getServiceName()
+                + GrpcConstants.STUB;
+        try {
+            Method[] methodsInStub = Class.forName(stubReference).getMethods();
+            for (Method method : methodsInStub) {
+                if (method.getName().equalsIgnoreCase(serviceConfigs.getMethodName())) {
+                    rpcMethod = method;
+                    break;
+                }
+            }
+            if (rpcMethod == null) { //only if user has provided a wrong method name
+                throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
+                        "provided in the url, provided method name: " + serviceConfigs.getMethodName() +
+                        "expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
+                        streamID));
+            }
+        } catch (ClassNotFoundException e) {
+            throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid service name " +
+                    "provided in the url, provided service name: '" + serviceConfigs
+                    .getFullyQualifiedServiceName() + "'", e);
+        }
+        return rpcMethod;
     }
 }

--- a/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcSink.java
@@ -368,7 +368,7 @@ public class GrpcSink extends AbstractGrpcSink {
                 throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
                         "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
                         "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
-                        streamID));
+                        streamID), e);
             }
         }
     }
@@ -396,7 +396,7 @@ public class GrpcSink extends AbstractGrpcSink {
                     throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
                             "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
                             "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
-                            streamID));
+                            streamID), e);
                 }
             } else {
                 requestObserver.onNext(payload);
@@ -468,7 +468,8 @@ public class GrpcSink extends AbstractGrpcSink {
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
                     "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
-                    "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName, streamID));
+                    "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName, streamID)
+            , e);
         }
     }
 }

--- a/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcSink.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/sink/GrpcSink.java
@@ -50,9 +50,14 @@ import static io.siddhi.extension.io.grpc.util.GrpcUtils.getRpcMethodList;
                 "This extension publishes event data encoded into GRPC Classes as defined in the user input " +
                 "jar. This extension has a default gRPC service classes added. The default service is called " +
                 "\"EventService\". Please find the protobuf definition [here](https://github.com/siddhi-io/" +
-                "siddhi-io-grpc/tree/master/component/src/main/resources/EventService.proto). This grpc sink is " +
-                "used for scenarios where we send a request and don't expect a response back. I.e getting a " +
-                "google.protobuf.Empty response back.",
+                "siddhi-io-grpc/tree/master/component/src/main/resources/EventService.proto). If we want to use our " +
+                "custom gRPC services, we have to  pack auto-generated gRPC service classes and  protobuf classes " +
+                "into a jar file and add it into the project classpath (or to the `jars` folder in the `siddhi-" +
+                "tooling` folder if we use it with `siddhi-tooling`). Please find the custom protobuf definition that" +
+                " uses in examples [here](https://github.com/siddhi-io/siddhi-io-grpc/tree/master/component/src/main/" +
+                "resources/sample.proto). This grpc sink is used for scenarios where we send a request and don't " +
+                "expect a response back. I.e getting a google.protobuf.Empty response back.",
+
         parameters = {
                 @Parameter(
                         name = "publisher.url",
@@ -219,7 +224,8 @@ import static io.siddhi.extension.io.grpc.util.GrpcUtils.getRpcMethodList;
                         description = "Here a stream named FooStream is defined with grpc sink. A grpc server should" +
                                 " be running at 134.23.43.35 listening to port 8080 since there is no mapper " +
                                 "provided, attributes of stream definition should be as same as the attributes of " +
-                                "protobuf message definition"
+                                "protobuf message definition."
+
                 ),
                 @Example(syntax = "" +
                         "@sink(type='grpc',\n" +
@@ -254,11 +260,9 @@ import static io.siddhi.extension.io.grpc.util.GrpcUtils.getRpcMethodList;
                         "floatValue float,doubleValue double);",
                         description = "Here in the grpc sink, we are sending a stream of requests to the server that " +
                                 "runs on 194.23.98.100 and port 8888. When we need to send a stream of requests from " +
-                                "the grpc sink we have to define a client stream RPC method(look the sample proto " +
-                                "file that provided in the resource folder [here](https://github.com/siddhi-io/siddhi" +
-                                "-io-grpc/tree/master/component/src/main/resources)).Then the siddhi will identify " +
-                                "whether it's a unary method or a stream method and send requests according to the " +
-                                "method type."
+                                "the grpc sink we have to define a client stream RPC method.Then the siddhi will " +
+                                "identify whether it's a unary method or a stream method and send requests according " +
+                                "to the method type."
                 )
         }
 )

--- a/component/src/main/java/io/siddhi/extension/io/grpc/source/GenericServiceServer.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/source/GenericServiceServer.java
@@ -226,7 +226,7 @@ public class GenericServiceServer {
             }
         } catch (IOException e) {
             if (e.getCause() instanceof BindException) {
-                throw new SiddhiAppValidationException(siddhiAppName + ": " + streamID + ": Another " +
+                throw new SiddhiAppRuntimeException(siddhiAppName + ": " + streamID + ": Another " +
                         "server is already running on the port " + grpcServerConfigs.getServiceConfigs().getPort() +
                         ". Please provide a different port");
             } else {

--- a/component/src/main/java/io/siddhi/extension/io/grpc/source/GrpcSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/source/GrpcSource.java
@@ -123,21 +123,21 @@ import static io.siddhi.extension.io.grpc.util.GrpcUtils.getRpcMethodList;
                 @Parameter(
                         name = "enable.ssl",
                         description = "to enable ssl. If set to true and truststore.file is not given then it will " +
-                                "be set to default carbon jks by default" ,
+                                "be set to default carbon jks by default",
                         type = {DataType.BOOL},
                         optional = true,
                         defaultValue = "FALSE"),
                 @Parameter(
                         name = "threadpool.size",
                         description = "Sets the maximum size of threadpool dedicated to serve requests at the gRPC " +
-                                "server" ,
+                                "server",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "100"),
                 @Parameter(
                         name = "threadpool.buffer.size",
                         description = "Sets the maximum size of threadpool buffer " +
-                                "server" ,
+                                "server",
                         type = {DataType.INT},
                         optional = true,
                         defaultValue = "100"),
@@ -266,8 +266,8 @@ public class GrpcSource extends AbstractGrpcSource {
             }
             if (rpcMethod == null) { //only if user has provided a wrong method name
                 throw new SiddhiAppValidationException(siddhiAppName + ":" + streamID + ": Invalid method name " +
-                        "provided in the url, provided method name: " + serviceConfigs.getMethodName() +
-                        "expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
+                        "provided in the url, provided method name: '" + serviceConfigs.getMethodName() +
+                        "', expected one of these methods: " + getRpcMethodList(serviceConfigs, siddhiAppName,
                         streamID));
             }
         } catch (ClassNotFoundException e) {

--- a/component/src/main/java/io/siddhi/extension/io/grpc/source/GrpcSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/source/GrpcSource.java
@@ -43,9 +43,14 @@ import static io.siddhi.extension.io.grpc.util.GrpcUtils.getRpcMethodList;
                 "service mode. By default this uses EventService. Please find the proto " +
                 "definition [here]" +
                 "(https://github.com/siddhi-io/siddhi-io-grpc/tree/master/component/src/main/resources/" +
-                "EventService.proto) In the default mode this source will use " +
-                "EventService consume method. This " +
-                "method will receive requests and injects them into stream through a mapper.",
+                "EventService.proto). In the default mode this source will use " +
+                "EventService consume method. If we want to use our " +
+                "custom gRPC services, we have to  pack auto-generated gRPC service classes and  protobuf classes " +
+                "into a jar file and add it into the project classpath (or to the `jars` folder in the `siddhi-" +
+                "tooling` folder if we use it with `siddhi-tooling`). Please find the custom protobuf definition that" +
+                " uses in examples [here](https://github.com/siddhi-io/siddhi-io-grpc/tree/master/component/src/main/" +
+                "resources/sample.proto)." +
+                " This method will receive requests and injects them into stream through a mapper.",
         parameters = {
                 @Parameter(
                         name = "receiver.url",

--- a/component/src/main/resources/sample.proto
+++ b/component/src/main/resources/sample.proto
@@ -6,8 +6,7 @@ option java_package = "io.siddhi.extension.io.grpc.proto";
 
 import "google/protobuf/empty.proto";
 
-message Request
-{
+message Request {
     string stringValue = 1;
     int32 intValue = 2;
     int64 longValue = 3;
@@ -17,9 +16,7 @@ message Request
 
 }
 
-
-message Response
-{
+message Response {
     string stringValue = 1;
     int32 intValue = 2;
     int64 LongValue = 3;
@@ -28,25 +25,21 @@ message Response
     double doubleValue = 6;
 }
 
-message RequestWithMap
-{
+message RequestWithMap {
     string stringValue =1;
     int32 intValue = 2;
     map<string,string> map = 3;
 
 }
 
-message ResponseWithMap
-{
+message ResponseWithMap {
     string stringValue =1;
     int32 intValue = 2;
     map<string,string> map = 3;
 
 }
 
-
-service MyService
-{
+service MyService {
     rpc send(Request) returns(google.protobuf.Empty);
     rpc process(Request) returns(Response);
     rpc testMap(RequestWithMap) returns(ResponseWithMap);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ markdown_extensions:
 pages:
 - Information: index.md
 - API Docs:
+  - 1.0.1-SNAPSHOT: api/1.0.1-SNAPSHOT.md
   - latest: api/latest.md
   - 1.0.0-beta: api/1.0.0-beta.md
   - 1.0.0: api/1.0.0.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,6 @@ markdown_extensions:
 pages:
 - Information: index.md
 - API Docs:
-  - 1.0.1-SNAPSHOT: api/1.0.1-SNAPSHOT.md
   - latest: api/latest.md
   - 1.0.0-beta: api/1.0.0-beta.md
   - 1.0.0: api/1.0.0.md


### PR DESCRIPTION
## Purpose
> Add com.google.* and io.grpc.* to Export-package and move 'creating stub' code in the grpc sink from init to connect.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes