### PR TITLE
Handle rejected executions in a blocking manner

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/grpc/source/GenericServiceServer.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/source/GenericServiceServer.java
@@ -93,12 +93,10 @@ public class GenericServiceServer extends ServiceServer {
         threadPoolExecutor.setRejectedExecutionHandler(new RejectedExecutionHandler() {
             @Override
             public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-                logger.info(">>>>>>>>> [30_MAY_PREQA] Handling rejectedExecution. ExecutorService queue size is: " +
-                        ((ThreadPoolExecutor) executorService).getQueue().size());
                 try {
                     executor.getQueue().put(r);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    throw new SiddhiAppRuntimeException(siddhiAppName + ": " + streamID + ": " + e.getMessage(), e);
                 }
             }
         });
@@ -171,9 +169,6 @@ public class GenericServiceServer extends ServiceServer {
                         return new StreamObserver<Any>() {
                             @Override
                             public void onNext(Any value) {
-                                logger.info(">>>>>>>>> [30_MAY_PREQA] onNext(). ExecutorService queue size is: " +
-                                        ((ThreadPoolExecutor) executorService).getQueue().size());
-
                                 try {
                                     Object requestMessageObject = requestClass.getDeclaredMethod(GrpcConstants.
                                             PARSE_FROM_METHOD_NAME, ByteString.class).invoke(requestClass, value.

--- a/component/src/main/java/io/siddhi/extension/io/grpc/source/GenericServiceServer.java
+++ b/component/src/main/java/io/siddhi/extension/io/grpc/source/GenericServiceServer.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
@@ -85,9 +86,24 @@ public class GenericServiceServer extends ServiceServer {
         this.requestClass = requestClass;
         super.lock = new ReentrantLock();
         super.condition = lock.newCondition();
-        this.executorService = new ThreadPoolExecutor(grpcServerConfigs.getThreadPoolSize(),
+        ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(grpcServerConfigs.getThreadPoolSize(),
                 grpcServerConfigs.getThreadPoolSize(), 0L, TimeUnit.MILLISECONDS,
                 new LinkedBlockingQueue<>(grpcServerConfigs.getThreadPoolBufferSize()));
+
+        threadPoolExecutor.setRejectedExecutionHandler(new RejectedExecutionHandler() {
+            @Override
+            public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+                logger.info(">>>>>>>>> [30_MAY_PREQA] Handling rejectedExecution. ExecutorService queue size is: " +
+                        ((ThreadPoolExecutor) executorService).getQueue().size());
+                try {
+                    executor.getQueue().put(r);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+        this.executorService = threadPoolExecutor;
+
         setServerPropertiesToBuilder(siddhiAppName, streamID);
         addServicesAndBuildServer(siddhiAppName, streamID);
     }
@@ -155,6 +171,9 @@ public class GenericServiceServer extends ServiceServer {
                         return new StreamObserver<Any>() {
                             @Override
                             public void onNext(Any value) {
+                                logger.info(">>>>>>>>> [30_MAY_PREQA] onNext(). ExecutorService queue size is: " +
+                                        ((ThreadPoolExecutor) executorService).getQueue().size());
+
                                 try {
                                     Object requestMessageObject = requestClass.getDeclaredMethod(GrpcConstants.
                                             PARSE_FROM_METHOD_NAME, ByteString.class).invoke(requestClass, value.


### PR DESCRIPTION
## Purpose
> $Subject. Fixes https://github.com/wso2/api-manager/issues/1826

This PR adds a `rejectionExecutionHandler` for the threadpool executor, which executes as follows:
- Thread pool will initially have `threadpool.size` number of threads.
- Since `threadpool.buffer.size` has not been configured, it will default to `100`.
- After this threadpool buffer (i.e: the worker queue of the threadpool executor) - which is a `LinkedBlockingQueue` fills, the `rejectionExecutionHandler` will `put` upcoming threads to this queue, in a blocking manner.
  ```
   executor.getQueue().put(r);
  ```

On a side note, in addition to this, `threadpool.buffer.size` can be tuned up as well, by providing `threadpool.buffer.size` as follows:
```
@source(type='grpc',
       receiver.url='...', 
       threadpool.size=...,
       threadpool.buffer.size='13000', -- NOTE THIS
       @map(type='protobuf'))
``` 

With this change, `RejectedExecutionException` are not expected since the `rejectionExecutionHandler` handles it.