### PR TITLE
Fix bundle Import-Package: correct com.google.common + add gson, commons-lang3

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -176,7 +176,9 @@
                             org.wso2.grpc.*, <!-- auto-gen classes -->
                         </Private-Package>
                         <Import-Package>
-                            com.google.guava.*;version="${guava.version.range}",
+                            com.google.common.*;version="${guava.version.range}",
+                            com.google.gson.*,
+                            org.apache.commons.lang3.*,
                             *;resolution:=optional
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>


### PR DESCRIPTION
## Problem
The `siddhi-io-grpc` OSGi bundle's `<Import-Package>` directive in `component/pom.xml` has been silently incorrect:

- Declares `com.google.guava.*` — there is no package by that name; the Guava package is `com.google.common.*`.
- Doesn't declare `com.google.gson.*` or `org.apache.commons.lang3.*`, even though the inlined `io.grpc.*` bytecode (from `<Export-Package>io.grpc.*</Export-Package>`) and the extension's own code reference them at runtime.
- A trailing `*;resolution:=optional` swallows the gap silently, so neither `mvn package` nor OSGi resolution flags it. Runtime, however, throws `NoClassDefFoundError`/`NoSuchMethodError` from `NettyServerBuilder.<clinit>` when the platform doesn't pre-stage these deps.

Surfaced during SI 4.4.0 smoke-testing of `13_GrpcServer.siddhi`: the editor's plain-classpath runner failed inside `<clinit>` because `gson` and `commons-lang3` weren't on the classpath. We worked around it at the catalog layer in [wso2/carbon-analytics#2038](https://github.com/wso2/carbon-analytics/pull/2038); this PR fixes the bundle metadata upstream.

## Fix
Single edit in `component/pom.xml`'s `<Import-Package>`:
- Typo: `com.google.guava.*` → `com.google.common.*` (re-uses the existing `\${guava.version.range}` from the WSO2 parent).
- Add explicit `com.google.gson.*`.
- Add explicit `org.apache.commons.lang3.*`.
- Keep `*;resolution:=optional` as a defensive catch-all.

No version bumps, no plugin changes, no other pom blocks touched. Bundle contents and exports unchanged.

## Verification
- ` ``` mvn -Dmaven.test.skip=true -Dspotbugs.skip=true clean package ``` ` → BUILD SUCCESS
- ` ``` unzip -t component/target/siddhi-io-grpc-1.0.15-SNAPSHOT.jar ``` ` → \`No errors detected in compressed data\`
- Bundle manifest now lists `com.google.common.*`, `com.google.gson.stream;version=\"[2.10,...)\"`, `org.apache.commons.lang3.builder` in `Import-Package`.